### PR TITLE
fix(services): a missed reference to the old package name

### DIFF
--- a/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
+++ b/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
@@ -1,1 +1,1 @@
-com.bedatadriven.jackson.datatype.jts.JtsModule
+com.desoss.jackson.datatype.jts.JtsModule


### PR DESCRIPTION
Java has some fancy service loader design that loads these classes [java doc](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html)

Inside this service file, it specifies the implementations of an interface (the filename in this case, `com.fasterxml.jackson.databind.Module`)

This was missed (Understandably!!), and the code compiles and usually works, but I'm using jersey/glassfish which are triggering a call to
```java
ObjectMapper.findModules(null);
```

Which:
* Causes Jackson to load its modules through the ServiceProvider
  * That discovers this file,
    * Which points the service loader to the class `com.bedatadriven.jackson.datatype.jts.JtsModule`
      * Which doesn't exist (Some variation of ClassNotFound)

This change points it at the correct module.

---

I think my temporary workaround will be to include BOTH jackson-datatype-jts dependencies (betadriven and desoss) in my project, so that when desoss specifies to load betadriven, it will succeed (though, weirdly).

I haven't tested this, but maybe it helps you out.